### PR TITLE
Add QUESTIONNAIRE_CORE_ENABLED_QUESTION_TYPES setting

### DIFF
--- a/questionnaire_core/apps.py
+++ b/questionnaire_core/apps.py
@@ -9,4 +9,10 @@ class QuestionnaireCoreConfig(AppConfig):
 
     def ready(self):
         # validate settings on startup
-        from . import settings  # NOQA
+        from . import settings
+
+        # update question type choices on `Question` model
+        from .models import Question
+        question_type_choices = [(qt.meta.name, qt.meta.verbose_name) for qt in settings.active_question_types]
+        question_type_field = Question._meta.get_field('question_type')
+        question_type_field.choices = question_type_choices

--- a/questionnaire_core/models/questionnaire.py
+++ b/questionnaire_core/models/questionnaire.py
@@ -13,7 +13,7 @@ from ..forms import QuestionnaireFormBase
 from ..question_types import QuestionTypeRegistry
 
 
-def available_question_types():
+def builtin_question_types():
     for question_type in sorted(QuestionTypeRegistry.get_question_types().values(), key=lambda q: q.meta.verbose_name):
         yield (question_type.meta.name, question_type.meta.verbose_name)
 
@@ -74,7 +74,7 @@ class Questionnaire(models.Model):
 class Question(OrderedModel):
     questionnaire = models.ForeignKey(Questionnaire, related_name='questions', on_delete=models.CASCADE)
     question_text = models.CharField(max_length=5000)
-    question_type = QuestionTypeField(max_length=32, choices=available_question_types())
+    question_type = QuestionTypeField(max_length=32, choices=builtin_question_types())
     question_options = JSONField(blank=True, default=dict)
     required = models.BooleanField(default=True)
 

--- a/questionnaire_core/settings.py
+++ b/questionnaire_core/settings.py
@@ -5,10 +5,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import Storage
 from django.utils.module_loading import import_string
 
+from .question_types import QuestionTypeRegistry
+
 
 upload_storage = None
 upload_to_handler = None
 upload_allowed_file_extensions = tuple()
+active_question_types = list()
 
 # validate & load QUESTIONNAIRE_CORE_UPLOAD_STORAGE
 if getattr(settings, 'QUESTIONNAIRE_CORE_UPLOAD_STORAGE', None):
@@ -39,3 +42,23 @@ if getattr(settings, 'QUESTIONNAIRE_CORE_UPLOAD_ALLOWED_FILE_EXTENSIONS', None):
         )
     else:
         upload_allowed_file_extensions = getattr(settings, 'QUESTIONNAIRE_CORE_UPLOAD_ALLOWED_FILE_EXTENSIONS')
+
+# validate & load QUESTIONNAIRE_CORE_ENABLED_QUESTION_TYPES
+if getattr(settings, 'QUESTIONNAIRE_CORE_ENABLED_QUESTION_TYPES', None):
+    enable_types = getattr(settings, 'QUESTIONNAIRE_CORE_ENABLED_QUESTION_TYPES')
+    for enable_type in enable_types:
+        if '.' in enable_type:
+            try:
+                active_type = import_string(enable_type)
+                active_question_types.append(active_type)
+            except ImportError:
+                raise ImproperlyConfigured('Could not import user-defined question type: {}'.format(enable_type))
+        else:
+            active_type = QuestionTypeRegistry.get_question_type(enable_type)
+            if active_type:
+                active_question_types.append(active_type)
+            else:
+                raise ImproperlyConfigured('Invalid name for builtin question type: {}'.format(enable_type))
+else:
+    # default: enable all builtin question types
+    active_question_types = QuestionTypeRegistry.get_question_types().values()


### PR DESCRIPTION
Allows to set up a list of active question types (builtin & custom).
By default all builtin question types are active.

For builtin question types use the name, for custom ones use a dotted
path to the question type class.

The valid chars for the question type name have been restricted to
a-z0-9_