### PR TITLE
Drop support for Python <3.8 and Django EOL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It heavily relies on django form fields & widgets and uses JSON fields to store 
 ## Requirements
 
 - Python version 3.8+
-- [Django](https://www.djangoproject.com) version 2.2+
+- [Django](https://www.djangoproject.com) version 3.2+
 - [django-ordered-model](https://github.com/bfirsh/django-ordered-model)
 - A [PostgreSQL](https://www.postgresql.org/) Database (optional since Django 3.2)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # django-questionnaire-core
 
 A django application which can be used as a base / starting point for questionnaire functionality in your project.
-It heavily relies on django form fields & widgets and uses PostgreSQL JSON fields to store the results.
+It heavily relies on django form fields & widgets and uses JSON fields to store the results.
 
 ## Requirements
 
-- Python version 3.6+
+- Python version 3.8+
 - [Django](https://www.djangoproject.com) version 2.2+
 - [django-ordered-model](https://github.com/bfirsh/django-ordered-model)
-- A [PostgreSQL](https://www.postgresql.org/) Database
+- A [PostgreSQL](https://www.postgresql.org/) Database (optional since Django 3.2)
 
 
 ## Quick start
@@ -78,10 +78,10 @@ It heavily relies on django form fields & widgets and uses PostgreSQL JSON field
     python -m pip install --upgrade setuptools wheel
     ```
 
-2. Install Django (the `example_app` expects django 3.1):
+2. Install Django (the `example_app` expects django 3.2):
 
     ```bash
-    python -m pip install Django~=3.1.0 django-ordered-model psycopg2
+    python -m pip install Django~=3.2.0 django-ordered-model psycopg2
     ```
 
 3. Install tox, isort & flake8

--- a/questionnaire_core/__init__.py
+++ b/questionnaire_core/__init__.py
@@ -1,2 +1,0 @@
-name = "questionnaire_core"
-default_app_config = "questionnaire_core.apps.QuestionnaireCoreConfig"

--- a/questionnaire_core/admin.py
+++ b/questionnaire_core/admin.py
@@ -1,18 +1,12 @@
 import json
 
 from django.contrib import admin
+from django.db.models import JSONField
 from django.forms import widgets
 
 from ordered_model.admin import OrderedTabularInline
 
 from .models import Question, QuestionAnswer, Questionnaire, QuestionnaireResult
-
-
-try:
-    # there is no difference in the (postgres) schema, so we can easily swap between the two
-    from django.db.models import JSONField
-except ImportError:
-    from django.contrib.postgres.fields.jsonb import JSONField
 
 
 try:

--- a/questionnaire_core/apps.py
+++ b/questionnaire_core/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class QuestionnaireCoreConfig(AppConfig):
     name = "questionnaire_core"
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         # validate settings on startup

--- a/questionnaire_core/migrations/0001_initial.py
+++ b/questionnaire_core/migrations/0001_initial.py
@@ -4,15 +4,9 @@ from __future__ import unicode_literals
 
 import django.db.models.deletion
 from django.db import migrations, models
+from django.db.models import JSONField
 
 import questionnaire_core.fields
-
-
-try:
-    # there is no difference in the (postgres) schema, so we can easily swap between the two
-    from django.db.models import JSONField
-except ImportError:
-    from django.contrib.postgres.fields.jsonb import JSONField
 
 
 class Migration(migrations.Migration):

--- a/questionnaire_core/models/questionnaire.py
+++ b/questionnaire_core/models/questionnaire.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django.db import models, transaction
+from django.db.models import JSONField
 from django.utils.text import Truncator
 
 from ordered_model.models import OrderedModel
@@ -8,13 +9,6 @@ from ordered_model.models import OrderedModel
 from ..fields import QuestionTypeField
 from ..forms import QuestionnaireFormBase
 from ..question_types import QuestionTypeRegistry
-
-
-try:
-    # there is no difference in the (postgres) schema, so we can easily swap between the two
-    from django.db.models import JSONField
-except ImportError:
-    from django.contrib.postgres.fields.jsonb import JSONField
 
 
 def builtin_question_types():

--- a/questionnaire_core/models/result.py
+++ b/questionnaire_core/models/result.py
@@ -1,18 +1,12 @@
 from collections import OrderedDict
 
 from django.db import models
+from django.db.models import JSONField
 
 from ordered_model.models import OrderedModel
 
 from ..fields import DynamicStorageFileField
 from .questionnaire import Question, Questionnaire
-
-
-try:
-    # there is no difference in the (postgres) schema, so we can easily swap between the two
-    from django.db.models import JSONField
-except ImportError:
-    from django.contrib.postgres.fields.jsonb import JSONField
 
 
 class QuestionnaireResultManager(models.Manager):

--- a/questionnaire_core/question_types/boolean.py
+++ b/questionnaire_core/question_types/boolean.py
@@ -1,11 +1,5 @@
-import django
 from django import forms
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/choices.py
+++ b/questionnaire_core/question_types/choices.py
@@ -1,11 +1,5 @@
-import django
 from django import forms
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/file_upload.py
+++ b/questionnaire_core/question_types/file_upload.py
@@ -1,17 +1,11 @@
 import os
 from contextlib import suppress
 
-import django
 from django import forms
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.forms import widgets
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/multiple.py
+++ b/questionnaire_core/question_types/multiple.py
@@ -1,12 +1,6 @@
-import django
 from django import forms
 from django.forms import widgets
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/number.py
+++ b/questionnaire_core/question_types/number.py
@@ -1,13 +1,7 @@
 from decimal import Decimal
 
-import django
 from django import forms
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/range.py
+++ b/questionnaire_core/question_types/range.py
@@ -1,12 +1,6 @@
-import django
 from django import forms
 from django.forms import widgets
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/questionnaire_core/question_types/text.py
+++ b/questionnaire_core/question_types/text.py
@@ -1,11 +1,5 @@
-import django
 from django import forms
-
-
-if django.VERSION < (3, 2):
-    from django.utils.translation import ugettext_lazy as _
-else:
-    from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import QuestionTypeBase
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-questionnaire-core
-version = 1.3.4
+version = 1.4.0
 author = anfema GmbH
 author_email = contact@anfe.ma
 description = A django application which can be used as a base for questionnaire functionality
@@ -10,15 +10,10 @@ license = MIT
 license_files = LICENSE
 url = https://github.com/anfema/django-questionnaire-core
 classifiers =
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -28,11 +23,11 @@ classifiers =
 test_suite = runtests.run_tests
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 packages = find:
 include_package_data = true
 install_requires =
-    django>=2.2
+    django>=3.2
     django-ordered-model
 
 [options.packages.find]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,7 +20,7 @@ INSTALLED_APPS = (
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
+        "ENGINE": "django.db.backends.sqlite3",
         "NAME": "questionnaire_core",
     },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -46,10 +46,3 @@ commands = isort --check-only --diff questionnaire_core tests
 changedir = {toxinidir}
 deps = black
 commands = black --check {toxinidir}
-
-[travis]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39, flake8, isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 3.18
 envlist =
-    py{36,37}-django{22,31,32}
-    py{38,39,310,311}-django{22,31,32,40,41,42}
+    py{38,39,310}-django32
+    py{38,39,310,311}-django{41,42}
     flake8
     isort
     black
@@ -16,10 +16,7 @@ commands =
 [testenv]
 deps =
     -rtest_requirements.txt
-    django22: Django~=2.2.0
-    django31: Django~=3.1.0
     django32: Django~=3.2.0
-    django40: Django~=4.0.0
     django41: Django~=4.1.0
     django42: Django~=4.2.0
 


### PR DESCRIPTION
Drop support for:
- Python 3.6 & 3.7
- Django 2.2, 3.1, & 4.0